### PR TITLE
fix: add initial value for callbacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@ export class Timeout {
     }
 
     private _startedAt: number;
-    private _callbacks: (() => void)[];
-    private _rejecters: (() => void)[];
+    private _callbacks: (() => void)[] = [];
+    private _rejecters: (() => void)[] = [];
     private _timeLeft: number;
     private _timerId: any; // not possible in any other way
 


### PR DESCRIPTION
`rejectors` wasn't initialized and it throws the following error if you call `stop()`:
`TypeError: Cannot read properties of undefined (reading 'splice')`